### PR TITLE
maintain dirty state of workflow column

### DIFF
--- a/lib/workflow-activerecord.rb
+++ b/lib/workflow-activerecord.rb
@@ -18,8 +18,13 @@ module WorkflowActiverecord
     # On transition the new workflow state is immediately saved in the
     # database.
     def persist_workflow_state(new_value)
-      # Rails 3.1 or newer
-      update_column self.class.workflow_column, new_value
+      # set dirty state of the column
+      self[self.class.workflow_column] = new_value
+      # in rails 5 update_column removes the dirty state on the instance
+      # using the class method maintains the dirty state
+      self.class
+        .where(self.class.primary_key => self[self.class.primary_key])
+        .update_all(self.class.workflow_column => new_value)
     end
 
     private


### PR DESCRIPTION
This is a recreation of a merge we had on a branch https://github.com/geekq/workflow/compare/develop...Ibotta:master but have since lost reference to the PRs as they were when we added them.

This is work in progress - I'm currently evaluating if this is still necessary or not.

