### PR TITLE
Support Rails 6.1

### DIFF
--- a/gemfiles/activerecord-6.1.Gemfile
+++ b/gemfiles/activerecord-6.1.Gemfile
@@ -1,3 +1,3 @@
 eval_gemfile File.join(File.dirname(__FILE__), "../Gemfile")
 
-gem 'activerecord', '~> 6.1.0.beta1'
+gem 'activerecord', '~> 6.1.0'

--- a/workflow_activerecord.gemspec
+++ b/workflow_activerecord.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
     "README.md"
   ]
 
-  rails_versions = ['>= 3.0', '< 6.1']
+  rails_versions = ['>= 3.0', '< 6.2']
 
   gem.required_ruby_version = '>= 2.3'
 


### PR DESCRIPTION
👋 @geekq

This adds support for the expected Rails 6.1 official release.

This also changed the ActiveRecord gemfile which is currently commented out in the spec, but I expect we'll want to change this to the final 6.1 gem once released.

At @podia we've been using the gem with the Release candidates with no issues or unexpected behavior in production.

It appears we just need a bump to the Gemspec + a release for supporting the upcoming Rails 6.1 final release and everything seems stable on this front. 
